### PR TITLE
Enable GitHub sponsors

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,2 @@
+github:
+  - jrbeverly


### PR DESCRIPTION
Enable GitHub sponsors on this repository, experimenting with the `funding.yml` file.