### PR TITLE
Enable dependabot in the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: "daily"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,34 @@
+name: Dependabot
+permissions: read-all
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/dependabot.yml
+      - cmd/**
+      - internal/**
+      - pkg/**
+      - .dockerignore
+      - .golangci.yml
+      - Dockerfile
+      - go.mod
+      - go.sum
+
+jobs:
+  verify:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bdb12b622a910dfdc99a31fdfe6f45a16bc287a4 # v1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415 # v3
+
+      - name: Build final image
+        run: docker build -t final-image .


### PR DESCRIPTION
Track the GitHub Actions, Dockerfiles and Golang dependencies.