### PR TITLE
Encode GitHub Actions secrets as files in source

### DIFF
--- a/.github/secrets.yml
+++ b/.github/secrets.yml
@@ -1,0 +1,42 @@
+apiVersion: 1.0.0
+secrets:
+  aws_access_key_id:
+    name: aws_access_key_id
+    scope: [actions, dependabot]
+    annotations:
+      aws.example.com/src: aws-federated-sts
+      aws.example.com/name: github-config-in-code
+  aws_secret_access_key:
+    name: AWS_SECRET_ACCESS_KEY
+    scope: [actions, dependabot]
+    annotations:
+      aws.example.com/src: aws-federated-sts
+      aws.example.com/name: github-config-in-code
+  aws_session_token:
+    name: AWS_SESSION_TOKEN
+    scope: [actions, dependabot]
+    annotations:
+      aws.example.com/src: aws-federated-sts
+      aws.example.com/name: github-config-in-code
+  aws_default_region:
+    name: AWS_DEFAULT_REGION
+    scope: [actions, dependabot]
+    annotations:
+      aws.example.com/src: aws-federated-sts
+      aws.example.com/name: github-config-in-code
+      aws.example.com/path: public-key
+  signing_key:
+    name: ARTIFACTS_SIGN_KEY
+    scope: [actions]
+    annotations:
+      aws.example.com/src: aws-secretsmanager
+      aws.example.com/name: github-config-in-code
+      aws.example.com/path: public-key
+  signing_key_pub:
+    name: ARTIFACTS_SIGN_KEY_PUB
+    scope: [actions]
+    annotations:
+      aws.example.com/src: aws-secretsmanager
+      aws.example.com/name: github-config-in-code
+      aws.example.com/path: public-key
+


### PR DESCRIPTION
Encode the GitHub Actions secrets of the repository as files.

This allows external tools to provide these secrets, rather than relying on configuration in another repository, or manual setup.